### PR TITLE
op-mode: T3298: Fix bgp reset neighbor commands

### DIFF
--- a/templates/reset/ip/bgp/node.tag/ipv4/unicast/in/node.def
+++ b/templates/reset/ip/bgp/node.tag/ipv4/unicast/in/node.def
@@ -1,2 +1,2 @@
 help: Clear via soft reconfig inbound update
-run: vtysh -c " clear ip bgp $4 ipv4 unicast in"
+run: vtysh -c "clear ip bgp ipv4 unicast $4 in"

--- a/templates/reset/ip/bgp/node.tag/ipv4/unicast/in/prefix-filter/node.def
+++ b/templates/reset/ip/bgp/node.tag/ipv4/unicast/in/prefix-filter/node.def
@@ -1,2 +1,2 @@
 help: Clear out the existing ORF prefix-list
-run: vtysh -c " clear ip bgp $4 ipv4 unicast in prefix-filter"
+run: vtysh -c "clear ip bgp ipv4 unicast $4 in prefix-filter"

--- a/templates/reset/ip/bgp/node.tag/ipv4/unicast/out/node.def
+++ b/templates/reset/ip/bgp/node.tag/ipv4/unicast/out/node.def
@@ -1,2 +1,2 @@
 help: Clear via soft reconfig outbound update
-run: vtysh -c " clear ip bgp $4 ipv4 unicast out"
+run: vtysh -c "clear ip bgp ipv4 unicast $4 out"

--- a/templates/reset/ip/bgp/node.tag/ipv4/unicast/soft/in/node.def
+++ b/templates/reset/ip/bgp/node.tag/ipv4/unicast/soft/in/node.def
@@ -1,2 +1,2 @@
 help: Clear via soft reconfig inbound update
-run: vtysh -c " clear ip bgp $4 ipv4 unicast soft in"
+run: vtysh -c "clear ip bgp $4 ipv4 unicast soft in"

--- a/templates/reset/ip/bgp/node.tag/ipv4/unicast/soft/node.def
+++ b/templates/reset/ip/bgp/node.tag/ipv4/unicast/soft/node.def
@@ -1,2 +1,2 @@
 help: Clear via soft reconfig
-run: vtysh -c " clear ip bgp $4 ipv4 unicast soft"
+run: vtysh -c "clear ip bgp ipv4 unicast $4 soft"

--- a/templates/reset/ip/bgp/node.tag/ipv4/unicast/soft/out/node.def
+++ b/templates/reset/ip/bgp/node.tag/ipv4/unicast/soft/out/node.def
@@ -1,2 +1,2 @@
 help: Clear via soft reconfig outbound update
-run: vtysh -c " clear ip bgp $4 ipv4 unicast soft out"
+run: vtysh -c "clear ip bgp ipv4 unicast $4 soft out"

--- a/templates/show/ip/bgp/dampened-paths/node.def
+++ b/templates/show/ip/bgp/dampened-paths/node.def
@@ -1,2 +1,2 @@
 help: Show dampened BGP paths
-run: ${vyatta_bindir}/vtyshow.pl "$@"
+run: vtysh -c "show ip bgp dampening dampened-paths"


### PR DESCRIPTION
Fix op-mode commands for reset ip bgp ipv4 neighbors.
And fix for show dampened paths
